### PR TITLE
Implement configurator image and 2dlayout routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,15 @@ The Elfsquad Configurator Library allows you to easily interact with the [Config
 * `getConfigurationModels` Retrieves a list of all available configuration models.
 * `newConfiguration` Starts a new configuration session.
 * `openConfiguration` Open an existing configuration.
-* `updateRequirement` Update the value of a feature in the configuration.
-* `updateText` Update the text value of a feature in the configuration.
+* `getLayout3d` Retrieves the 3D layout settings for the configuration session.
+* `getSettings` Retrieves the configurator settings.
+
+## Configurator methods
+* `updateRequirement` Update the value of a feature in the configuration session.
+* `updateText` Update the text value of a feature in the configuration session.
 * `changeLanguage` Changes the language of the texts in the configuration session.
 * `getStepImage` Retrieves the step image for a step in the configuration session.
 * `getPdf` Generates a PDF document for the configuration session.
-* `getLayout3d` Retrieves the 3D layout settings for the configuration session.
-* `getSettings` Retrieves the configurator settings.
 
 ## Examples
 ```javascript
@@ -45,23 +47,23 @@ configuratorContext.getConfigurationModels().then((models) => {
 
             const feature = openedConfiguration.steps[0].features[0];
             
-            configuratorContext.updateRequirement(feature.id, true, 1).then((updateResult) => {
+            configurator.updateRequirement(feature.id, true, 1).then((updateResult) => {
                 console.log('updateResult', updateResult);
             });
 
-            configuratorContext.updateText(feature.id, 'test 123').then((updateResult) => {
+            configurator.updateText(feature.id, 'test 123').then((updateResult) => {
                 console.log('updateTextResult', updateResult);
             });
 
-            configuratorContext.changeLanguage(Object.keys(models.languages)[2]).then((updateResult) => {
+            configurator.changeLanguage(Object.keys(models.languages)[2]).then((updateResult) => {
                 console.log('changeLanguage', updateResult);
             });
 
-            configuratorContext.getStepImage(openedConfiguration.steps[0].id).then((image) => {
+            configurator.getStepImage(openedConfiguration.steps[0].id).then((image) => {
                 console.log('image', image);
             });
 
-            configuratorContext.getPdf().then((pdf) => {
+            configurator.getPdf().then((pdf) => {
                 console.log('pdf', pdf);
             });
 

--- a/src/configurator/ConfiguratorContext.ts
+++ b/src/configurator/ConfiguratorContext.ts
@@ -4,7 +4,8 @@ import { ConfigurationModels } from '../models/ConfigurationModels';
 import { Layout2d } from '../models/Layout2d';
 import { Layout3d } from '../models/Layout3d';
 import { LinkedConfigurationOverview } from '../models/LinkedConfigurationOverview';
-import {QuotationRequest} from '../models/QuotationRequest';
+import { OverviewGroups } from '../models/Overview';
+import { QuotationRequest } from '../models/QuotationRequest';
 import { Settings } from '../models/Settings';
 import { AuthenticationMethod, IConfiguratorOptions } from './IConfiguratorOptions';
 
@@ -104,6 +105,13 @@ export class ConfiguratorContext extends EventTarget {
     public async getLinkedConfigurationOverview() : Promise<LinkedConfigurationOverview>{
         let result = await this._get(`${this._options.apiUrl}/configurator/1/configurator/${this.rootConfiguration().id}/linkedconfigurations/overview`);
         return await result.json() as LinkedConfigurationOverview;
+    }
+    public async getOverview(configurationId: string | null = null): Promise<OverviewGroups[]> {
+        if (!configurationId) configurationId = this.rootConfiguration().id;
+        const result = await this._get(
+            `${this._options.apiUrl}/configurator/1/configurator/overview/multiple?configurationIds=${configurationId}`
+        );
+        return (await result.json()) as OverviewGroups[];
     }
     
     public onUpdate(f: (evt: CustomEvent<Configuration>) => void) {

--- a/src/configurator/ConfiguratorContext.ts
+++ b/src/configurator/ConfiguratorContext.ts
@@ -1,6 +1,7 @@
 import { AuthenticationContext } from '@elfsquad/authentication';
 import { Configuration } from '../models/Configuration';
 import { ConfigurationModels } from '../models/ConfigurationModels';
+import { Layout2d } from '../models/Layout2d';
 import { Layout3d } from '../models/Layout3d';
 import { LinkedConfigurationOverview } from '../models/LinkedConfigurationOverview';
 import {QuotationRequest} from '../models/QuotationRequest';
@@ -85,6 +86,13 @@ export class ConfiguratorContext extends EventTarget {
         if (language) url += `?lang=${language}`;
         let result = await this._get(url);
         return await result.json() as Settings;
+    }
+
+    public async getLayout2d(configurationId: string | null = null, stepId: string): Promise<Layout2d[]> {
+      if (!configurationId) configurationId = this.rootConfiguration().id;
+      if (!stepId) stepId = this.rootConfiguration().steps[0].id;
+      const result = await this._get(`${this._options.apiUrl}/configurator/1/configurator/${configurationId}/2dlayout?stepId=${stepId}`);
+      return (await result.json()) as Layout2d[];
     }
 
     public async getLayout3d(configurationId: string | null = null): Promise<Layout3d[]>{

--- a/src/models/Configuration.ts
+++ b/src/models/Configuration.ts
@@ -59,6 +59,15 @@ export class Configuration {
         await this._configuratorContext._updateConfiguration(this);
     }
 
+    public async updateImage(featureModelNodeId: string, textValue: string): Promise<void> {
+        const result = await this._configuratorContext._put(`${this._configuratorContext._options.apiUrl}/configurator/1/configurator/${this.id}/image`, {
+            featureModelNodeId,
+            textValue
+        });
+        this._applyConfigurationObject(await result.json());
+        await this._configuratorContext._updateConfiguration(this);
+    }
+  
     public async changeLanguage(languageIso: string): Promise<void> {
         let result = await this._configuratorContext._put(`${this._configuratorContext._options.apiUrl}/configurator/1/configurator/${this.id}/changeLanguage`, languageIso);
         this._applyConfigurationObject(await result.json());

--- a/src/models/Layout2d.ts
+++ b/src/models/Layout2d.ts
@@ -1,0 +1,25 @@
+
+export enum Layout2dType {
+    Standard = 0,
+    Magnifier = 1,
+}
+  
+export class Layout2d {
+    id: string;
+    stepId: string;
+    x: number;
+    y: number;
+    z: number;
+    type: Layout2dType;
+    url: string;
+    featureModelNodeIds: string[];
+    isHidden: boolean;
+    creatorId: string;
+    synced: boolean;
+    inactive: boolean;
+    createdDate: string;
+    updatedDate: string;
+    organizationId?: string;
+    reference?: string;
+}
+  

--- a/src/models/Overview.ts
+++ b/src/models/Overview.ts
@@ -1,0 +1,60 @@
+import { ConfigurationFeature } from './Configuration';
+import { Layout2d } from './Layout2d';
+
+export class Text {
+  value: string;
+  languageIso: string;
+  stepId: string;
+  type: number;
+  id: string;
+  creatorId: string;
+  synced: boolean;
+  inactive: boolean;
+  createdDate: string;
+  updatedDate: string;
+}
+
+export class Line {
+  feature: ConfigurationFeature;
+  depth: number;
+}
+export class VisibleSteps {
+  featureModelId?: string | number;
+  type: number;
+  texts: Text[];
+  order: number;
+  configuratorImages: Layout2d[];
+  hotspots: never[];
+  cameraPositions: never[];
+  requiredHotspots: boolean;
+  listviewEnabled: boolean;
+  sendDataOnConfigurationUpdate: boolean;
+  visibleNodes: string[];
+  useStepImageAsConfigurationImage: boolean;
+  hideInOrderEntry: boolean;
+  hideInShowroom: boolean;
+  hideInShowroomOverview: boolean;
+  hideOnDocument: boolean;
+  id: string;
+  creatorId: string;
+  synced: boolean;
+  inactive: boolean;
+  createdDate: string;
+  updatedDate: string;
+}
+
+export class Overview {
+  configurationId: string;
+  configurationCode: string;
+  root: ConfigurationFeature;
+  lines: Line[];
+  visibleSteps: VisibleSteps;
+
+  basePrice: string;
+  additionalPrice: string;
+  totalPrice: string;
+}
+
+export type OverviewGroups {
+  groups: Overview[];
+}

--- a/src/models/Overview.ts
+++ b/src/models/Overview.ts
@@ -55,6 +55,7 @@ export class Overview {
   totalPrice: string;
 }
 
-export type OverviewGroups {
+export type OverviewGroups = {
+
   groups: Overview[];
 }


### PR DESCRIPTION
This pull request implements 2 new functions that are missing:

1. `configurator/1/configurator/<ifeatureId>/image`: Store the url of an uploaded image in an "image picker" feature
2. `configurator/<configurationId>/2dlayout?stepId=<stepId>`: Get the list of images show in the configurator for this particular step.