### PR TITLE
feat(EC-24455): add contactEmail to showroom Settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elfsquad/configurator",
-  "version": "3.6.4",
+  "version": "3.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elfsquad/configurator",
-      "version": "3.6.4",
+      "version": "3.6.5",
       "license": "MIT",
       "dependencies": {
         "@elfsquad/authentication": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elfsquad/configurator",
-  "version": "3.6.4",
+  "version": "3.6.5",
   "description": "",
   "scripts": {
     "test": "jest",

--- a/src/models/Settings.ts
+++ b/src/models/Settings.ts
@@ -51,6 +51,7 @@ export interface Settings {
   onConfigurationLeavePopup: boolean;
   footerMessage?: string;
   copyrightMessage?: string;
+  contactEmail?: string;
   welcomePageLayout?: WelcomePageLayout;
 }
 


### PR DESCRIPTION
## Summary

Adds an optional \`contactEmail?: string\` field to the showroom \`Settings\` interface.

When configured per showroom domain (via EMS → Showroom Settings → Pages → Other), the new showroom's welcome page will render the "Need help? Contact us" text as a \`mailto:\` link pointing at this address. When unset, the link is hidden.

This is a minimal type-only addition — no runtime behavior, no new endpoints. The field is populated from the existing configurator settings endpoint once the backend lands.

## Changes

- \`src/models/Settings.ts\` — add \`contactEmail?: string\` next to the existing \`footerMessage\` / \`copyrightMessage\` fields (same shape: optional string).
- \`package.json\` / \`package-lock.json\` — bump version **3.6.4 → 3.6.5** (patch: additive optional field, backward compatible).

## Backend + UI context

- Backend (CPQ entity + migration + EMS editor UI): [Elfsquad/cpq#10176](https://github.com/Elfsquad/cpq/pull/10176)
- Showroom consumer (reads \`settings.contactEmail\` in \`NeedHelpText.tsx\`): follow-up PR in the showroom repo, depends on this package being published.

## Release

Once this PR is merged, @marcin-owerczuk will publish **3.6.5** to npm manually, then open the showroom PR that bumps the dependency and wires the mailto link.

## Related

- Ticket: [EC-24455](https://elfsquad.atlassian.net/browse/EC-24455)
- Epic: [EC-23367 — New Showroom](https://elfsquad.atlassian.net/browse/EC-23367)