### PR TITLE
feat(EL-647): add sidebarPosition to Settings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ export {
   WelcomePageText,
   Settings,
   WelcomePageLayout,
+  SidebarPosition,
 } from "./models/Settings";
 export { QuotationRequest } from "./models/QuotationRequest";
 export { Feature, UnitOfMeasurement } from "./models/Feature";

--- a/src/models/Settings.ts
+++ b/src/models/Settings.ts
@@ -54,6 +54,7 @@ export interface Settings {
   copyrightMessage?: string;
   contactEmail?: string;
   welcomePageLayout?: WelcomePageLayout;
+  sidebarPosition?: SidebarPosition;
   googleTagManagerContainerId?: string | null;
   enableRecaptcha?: boolean;
   recaptchaSiteKey?: string;
@@ -64,6 +65,12 @@ export const WelcomePageLayout = {
   SplitScreen: 1,
 } as const;
 export type WelcomePageLayout = (typeof WelcomePageLayout)[keyof typeof WelcomePageLayout];
+
+export const SidebarPosition = {
+  Left: 0,
+  Right: 1,
+} as const;
+export type SidebarPosition = (typeof SidebarPosition)[keyof typeof SidebarPosition];
 
 export interface WelcomePageText {
   languageIso: string | undefined;


### PR DESCRIPTION
## Dependencies & merge order

Part of **EL-647** (configurator sidebar left/right of the viewer), which spans three PRs:

1. **Elfsquad/cpq#10701** — backend (setting + EF migration + admin UI). **Merge & deploy first**: the frontend reads `sidebarPosition` from the settings API.
2. **Elfsquad/showroom#254** — frontend (renders sidebar left/right). Merge **after** the backend is deployed.
3. **Elfsquad/configurator#34** — SDK `Settings` type. Independent; merge & publish anytime. Once published + bumped, a follow-up removes the showroom's temporary `Settings` augmentation.

**This PR is #3 (SDK types) — independent of merge order, but should publish so the showroom can drop its stopgap augmentation.**

---

## Summary
Adds a `sidebarPosition` field to the showroom `Settings` model so the showroom can render the configurator sidebar on the **left** or **right** of the viewer (EL-647).

- `sidebarPosition?: SidebarPosition` on the `Settings` interface
- `SidebarPosition` enum const + type (`Left = 0`, `Right = 1`), mirroring `WelcomePageLayout`
- Re-exported from `src/index.ts`

`Left (0)` is the default and matches the historical layout (sidebar left, viewer right).

## Context (cross-repo)
This is the SDK type contract for EL-647. The field is already served by the backend (cpq) and consumed by the showroom:
- Backend: `Elfsquad/cpq` — entity + migration + admin UI
- Frontend: `Elfsquad/showroom` — currently uses a local type augmentation as a stopgap; it will switch to this SDK type once a new version is published and bumped.

## Test impact
Types/const only; `npm run build` (webpack) passes. No runtime behavior in the SDK.
