### PR TITLE
chore: bump version to 3.6.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elfsquad/configurator",
-  "version": "3.6.7",
+  "version": "3.6.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elfsquad/configurator",
-      "version": "3.6.7",
+      "version": "3.6.8",
       "license": "MIT",
       "dependencies": {
         "@elfsquad/authentication": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elfsquad/configurator",
-  "version": "3.6.7",
+  "version": "3.6.8",
   "description": "",
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
## Why

The `3.6.8` GitHub release was tagged on `7c56ceb` (the EL-647 `sidebarPosition` merge, #34), but `package.json` was never bumped off `3.6.7`. As a result the **Publish to NPM** workflow built and tried to publish `3.6.7` again and npm rejected it:

```
npm error You cannot publish over the previously published versions: 3.6.7.
```

So `3.6.8` exists as a GitHub release/tag but never made it to npm (`latest` is still `3.6.7`).

## What

Bump `version` `3.6.7` → `3.6.8` in `package.json` + `package-lock.json` (same one-line bump as prior releases, e.g. 'Update the version to 3.6.4').

## After merge

The `3.6.8` release/tag currently points at the pre-bump commit, so re-running the existing release won't help — once this is merged, **re-create the `3.6.8` release** targeting the new `main` HEAD so the Publish workflow runs against a commit whose `package.json` is `3.6.8`.

Needed to unblock the showroom `@elfsquad/configurator` bump for EL-647.