### PR TITLE
feat(EL-789): add optional configurationId to Configuration.updateText/.updateImage

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ configuratorContext.getConfigurationModels().then((models) => {
                 console.log('updateTextResult', updateResult);
             });
 
+            // Optionally target a feature owned by a linked configuration by passing its id
+            configuration.updateText(feature.id, 'test 123', linkedConfigurationId).then((updateResult) => {
+                console.log('updateTextResult', updateResult);
+            });
+
             configuration.changeLanguage(Object.keys(models.languages)[2]).then((updateResult) => {
                 console.log('changeLanguage', updateResult);
             });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elfsquad/configurator",
-  "version": "3.6.8",
+  "version": "3.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elfsquad/configurator",
-      "version": "3.6.8",
+      "version": "3.6.9",
       "license": "MIT",
       "dependencies": {
         "@elfsquad/authentication": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elfsquad/configurator",
-  "version": "3.6.8",
+  "version": "3.6.9",
   "description": "",
   "scripts": {
     "test": "jest",

--- a/src/models/Configuration.spec.ts
+++ b/src/models/Configuration.spec.ts
@@ -108,6 +108,57 @@ describe("configuration", () => {
     expect(lastRequest.method).toBe("PUT");
   });
 
+  it("should pass configurationId in the body for updateText when supplied", async () => {
+    const configuration = await createTestConfiguration();
+
+    mockNextFetchResponse({ id: "test-id" });
+    await configuration.updateText("node_id", "abc", "linked-id");
+
+    expect(await lastRequest.json()).toEqual({
+      featureModelNodeId: "node_id",
+      textValue: "abc",
+      configurationId: "linked-id",
+    });
+  });
+
+  it("should omit configurationId from the body for updateText when not supplied", async () => {
+    const configuration = await createTestConfiguration();
+
+    mockNextFetchResponse({ id: "test-id" });
+    await configuration.updateText("node_id", "abc");
+
+    const body = await lastRequest.json();
+    expect(body).toEqual({ featureModelNodeId: "node_id", textValue: "abc" });
+    expect(body).not.toHaveProperty("configurationId");
+  });
+
+  it("should pass configurationId in the body for updateImage when supplied", async () => {
+    const configuration = await createTestConfiguration();
+
+    mockNextFetchResponse({ id: "test-id" });
+    await configuration.updateImage("node_id", "https://example.com/image.png", "linked-id");
+
+    expect(await lastRequest.json()).toEqual({
+      featureModelNodeId: "node_id",
+      textValue: "https://example.com/image.png",
+      configurationId: "linked-id",
+    });
+  });
+
+  it("should omit configurationId from the body for updateImage when not supplied", async () => {
+    const configuration = await createTestConfiguration();
+
+    mockNextFetchResponse({ id: "test-id" });
+    await configuration.updateImage("node_id", "https://example.com/image.png");
+
+    const body = await lastRequest.json();
+    expect(body).toEqual({
+      featureModelNodeId: "node_id",
+      textValue: "https://example.com/image.png",
+    });
+    expect(body).not.toHaveProperty("configurationId");
+  });
+
   it("should call correct endpoint for updateName", async () => {
     const configuration = await createTestConfiguration();
 

--- a/src/models/Configuration.ts
+++ b/src/models/Configuration.ts
@@ -101,15 +101,24 @@ export class Configuration {
    *
    * @param featureModelNodeId The id of the feature model node to update
    * @param textValue The text value to set on the feature
+   * @param configurationId Optional id of the linked configuration that owns the
+   * node, when it lives in a linked model rather than this one. Must be within this
+   * configuration's linked-configuration subtree; the backend validates it and falls
+   * back to resolving the owner itself when omitted or invalid.
    *
    * @returns A promise that resolves when the text value has been updated
    */
-  public async updateText(featureModelNodeId: string, textValue: string): Promise<void> {
+  public async updateText(
+    featureModelNodeId: string,
+    textValue: string,
+    configurationId?: string
+  ): Promise<void> {
     const result = await this._configuratorContext._put(
       `${this._configuratorContext.options.apiUrl}/configurator/3/configurator/${this.id}/text`,
       {
         featureModelNodeId,
         textValue,
+        ...(configurationId !== undefined ? { configurationId } : {}),
       }
     );
     this._applyConfigurationObject(await result.json());
@@ -128,15 +137,24 @@ export class Configuration {
    *
    * @param featureModelNodeId The id of the feature model node to update
    * @param textValue The image value to set on the feature
+   * @param configurationId Optional id of the linked configuration that owns the
+   * node, when it lives in a linked model rather than this one. Must be within this
+   * configuration's linked-configuration subtree; the backend validates it and falls
+   * back to resolving the owner itself when omitted or invalid.
    *
    * @returns A promise that resolves when the image value has been updated
    */
-  public async updateImage(featureModelNodeId: string, textValue: string): Promise<void> {
+  public async updateImage(
+    featureModelNodeId: string,
+    textValue: string,
+    configurationId?: string
+  ): Promise<void> {
     const result = await this._configuratorContext._put(
       `${this._configuratorContext.options.apiUrl}/configurator/3/configurator/${this.id}/image`,
       {
         featureModelNodeId,
         textValue,
+        ...(configurationId !== undefined ? { configurationId } : {}),
       }
     );
     this._applyConfigurationObject(await result.json());


### PR DESCRIPTION
## What

Adds an optional third `configurationId` parameter to `Configuration.updateText` and `Configuration.updateImage`. When supplied, it's passed through to the PUT body for `/text` and `/image`; when omitted, the body is unchanged.

This exposes, in the high-level SDK wrappers, the linked-configuration routing hint the backend gained in **EL-388**. It's the SDK-polish follow-up tracked by [EL-789](https://elfsquad.atlassian.net/browse/EL-789).

```ts
// unchanged — backend resolves the owning configuration itself
await configuration.updateText(nodeId, "hello");

// new — target a specific linked configuration that owns the node
await configuration.updateText(nodeId, "hello", linkedConfigurationId);
await configuration.updateImage(nodeId, imageUrl, linkedConfigurationId);
```

## What the hint does

`configurationId` identifies the configuration within this configuration's linked-configuration subtree that owns the node. The backend (`UpdateTextValueModel.ConfigurationId`) feeds it to the tree walker as a hint:

- It does **not** bypass the server-side walk. The walk still starts at the URL-root config (the authorization boundary) and validates the hint lives inside that subtree before honoring it — a hint outside the subtree, or one that doesn't contain the node, is discarded and the backend resolves the owner itself.
- Its real value is **disambiguation**: when the same node appears in more than one config in the subtree, the hint selects which owning configuration the write lands on (otherwise "root wins / first match"). The early-out is a secondary, best-effort speedup.

## Backwards compatibility

Fully backwards compatible. The parameter is optional and, when omitted, the request body is byte-identical to before — existing callers are unaffected, and the backend tolerates omission (resolves server-side).

## Version

Patch bump 3.6.8 → 3.6.9, matching the repo's convention of patch-bumping for additive features (cf. EL-647 → 3.6.8). `package.json` + `package-lock.json` synced via `npm version`.

## Tests

4 new tests in `Configuration.spec.ts` (supplied → body includes `configurationId`; omitted → body excludes it, for both methods). Full suite **36/36 green**, `tsc --noEmit` clean, eslint clean.
